### PR TITLE
add instructions to add lbl_longitude and lbl_latitude to files

### DIFF
--- a/issue_workflows/sf_neighbourhood_updates_pt_2.md
+++ b/issue_workflows/sf_neighbourhood_updates_pt_2.md
@@ -153,8 +153,12 @@ For existing features, probably don't modify the existing `min_zoom` and `max_zo
   - Default: `min_zoom`:`16`, rarely modify.
   - Default: `max_zoom`:`18`, rarely modify.
 
-Now to create or update the lbl:latitude and lbl:longitude attribute fields for all updated or new geometries in your geojson files: visit [mapshaper](https://mapshaper.org) one file at a time, click the box next to snap verticles, paste `each 'lbl_longitude=$.innerX , lbl_latitude=$.innerY'` into command line option. Then export the file as a geojson. Repeat this process for each file. 
+Now we need to create (or update) the `lbl:latitude` and `lbl:longitude` attribute properties for all updated or new geometries in your geojson files: visit [MapShaper](http://www.mapshaper.org) and do the following, one file at a time: 
 
+- Click the box next to snap verticles
+- Paste `each 'lbl_longitude=$.innerX , lbl_latitude=$.innerY'` into command line option
+- Export the file as a geojson
+- Repeat this process for each file
   
 ##Let's Recap
 

--- a/issue_workflows/sf_neighbourhood_updates_pt_2.md
+++ b/issue_workflows/sf_neighbourhood_updates_pt_2.md
@@ -152,6 +152,9 @@ For existing features, probably don't modify the existing `min_zoom` and `max_zo
 - `microhood`: 
   - Default: `min_zoom`:`16`, rarely modify.
   - Default: `max_zoom`:`18`, rarely modify.
+
+Now to create or update the lbl:latitude and lbl:longitude attribute fields for all updated or new geometries in your geojson files: visit [mapshaper](https://mapshaper.org) one file at a time, click the box next to snap verticles, paste `each 'lbl_longitude=$.innerX , lbl_latitude=$.innerY'` into command line option. Then export the file as a geojson. Repeat this process for each file. 
+
   
 ##Let's Recap
 


### PR DESCRIPTION
Here's instructions of how to add the fields to the lbl_longitude and lbl_latitude properties. These fields are generated in mapshaper. I only included the instructions for the online/web version. 
